### PR TITLE
Feature/paginate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "cookie-parser": "^1.4.6",
         "cross-env": "^7.0.3",
         "joi": "^17.11.0",
+        "nestjs-typeorm-paginate": "^4.0.4",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
@@ -8503,6 +8504,15 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/nestjs-typeorm-paginate": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nestjs-typeorm-paginate/-/nestjs-typeorm-paginate-4.0.4.tgz",
+      "integrity": "sha512-arinWDc78wPV/EYWMmLYyeMSE5Lae1FHWD/2QpOdTmHaOVqK4PYf19EqZBqT9gbbPugkNW9JAMz3G2WmvSgR/A==",
+      "peerDependencies": {
+        "@nestjs/common": "^6.1.1 || ^5.6.2 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "typeorm": "^0.3.0"
+      }
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cookie-parser": "^1.4.6",
     "cross-env": "^7.0.3",
     "joi": "^17.11.0",
+    "nestjs-typeorm-paginate": "^4.0.4",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,8 @@ import * as Joi from 'joi';
       ignoreEnvFile: process.env.NODE_ENV === 'prod',
       validationSchema: Joi.object({
         NODE_ENV: Joi.string().required(),
+        DOMAIN_URL: Joi.string().required(),
+        DOMAIN: Joi.string().required(),
         DATABASE_TYPE: Joi.string().valid('postgres').required(),
         DATABASE_HOST: Joi.string().required(),
         DATABASE_PORT: Joi.number().required(),

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -9,17 +9,23 @@ import { UserEntity } from '../users/entity/user.entity';
 
 @Injectable()
 export class AuthService {
-  private readonly tokenOptionBase = {
-    domain: this.configService.get('DOMAIN'),
-    path: '/',
-    httpOnly: true,
+  private readonly tokenOptionBase: {
+    domain: string;
+    path: string;
+    httpOnly: boolean;
   };
 
   constructor(
     private userService: UsersService,
     private jwtService: JwtService,
     private configService: ConfigService,
-  ) {}
+  ) {
+    this.tokenOptionBase = {
+      domain: this.configService.get('DOMAIN'),
+      path: '/',
+      httpOnly: true,
+    };
+  }
 
   async signUp(signUpDto: SignUpDto) {
     const salt = await bcrypt.genSalt();

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -9,6 +9,12 @@ import { UserEntity } from '../users/entity/user.entity';
 
 @Injectable()
 export class AuthService {
+  private readonly tokenOptionBase = {
+    domain: this.configService.get('DOMAIN'),
+    path: '/',
+    httpOnly: true,
+  };
+
   constructor(
     private userService: UsersService,
     private jwtService: JwtService,
@@ -52,10 +58,8 @@ export class AuthService {
     });
 
     return {
+      ...this.tokenOptionBase,
       accessToken: token,
-      domain: 'localhost',
-      path: '/',
-      httpOnly: true,
     };
   }
 
@@ -67,27 +71,20 @@ export class AuthService {
     });
 
     return {
+      ...this.tokenOptionBase,
       refreshToken: token,
-      domain: 'localhost',
-      path: '/',
-      httpOnly: true,
     };
   }
 
   getCookiesForLogOut() {
+    const logoutOption = {
+      ...this.tokenOptionBase,
+      maxAge: 0,
+    };
+
     return {
-      accessOption: {
-        domain: 'localhost',
-        path: '/',
-        httpOnly: true,
-        maxAge: 0,
-      },
-      refreshOption: {
-        domain: 'localhost',
-        path: '/',
-        httpOnly: true,
-        maxAge: 0,
-      },
+      accessOption: logoutOption,
+      refreshOption: logoutOption,
     };
   }
 }

--- a/src/posts/entity/post.entity.ts
+++ b/src/posts/entity/post.entity.ts
@@ -77,7 +77,7 @@ export class PostEntity {
   })
   tags: string[];
 
-  @OneToOne(() => ImageEntity, (image) => image.id, {
+  @OneToOne(() => ImageEntity, (image) => image.uid, {
     cascade: true,
     eager: true,
   })

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -26,28 +26,22 @@ export class PostsController {
     private configService: ConfigService,
   ) {}
 
-  /**
-   * TODO:
-   *  - [x] 페이지네이션을 잘 작동함. 날먹 개꿀
-   *  - [x] 문제는 검색 옵션. -> 이름으로 검색, 내용으로 검색, 작성자로 검색, 작성일로 검색 등등 기능 추가 필요
-   *  - [] 그리고 테스트 코드 수정해야함
-   */
   @Get()
   getAllPost(
-    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number = 1,
-    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number = 10,
-    @Query('title') title: string,
-    @Query('sort') sort: SortOptions = 'DESC',
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page?: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit?: number,
+    @Query('title') title?: string,
+    @Query('sort') sort?: SortOptions,
     @Query(
       'tags',
       new ParseArrayPipe({ items: String, separator: ',', optional: true }),
     )
-    tags: string[],
+    tags?: string[],
     @Query(
       'artTypes',
       new ParseArrayPipe({ items: String, separator: ',', optional: true }),
     )
-    artTypes: ArtType[],
+    artTypes?: ArtType[],
   ) {
     const paginationOptions = {
       page,
@@ -57,11 +51,14 @@ export class PostsController {
     const filterOptions: FilterOptions = {
       title,
       tags,
-      sort,
+      sort: sort || 'DESC',
       artTypes,
     };
 
-    return this.postsService.paginate(paginationOptions, filterOptions);
+    return this.postsService.getPostListPaginateWithFilter(
+      paginationOptions,
+      filterOptions,
+    );
   }
 
   @Get(':id')

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,11 +1,14 @@
 import {
   Body,
   Controller,
+  DefaultValuePipe,
   Delete,
   Get,
   Param,
+  ParseIntPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { PostsService } from './posts.service';
@@ -13,14 +16,33 @@ import { PostEntity } from './entity/post.entity';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { JwtAccessGuard } from '../auth/guards/jwt-access.guard';
+import { ConfigService } from '@nestjs/config';
 
 @Controller('posts')
 export class PostsController {
-  constructor(private readonly postsService: PostsService) {}
+  constructor(
+    private readonly postsService: PostsService,
+    private configService: ConfigService,
+  ) {}
 
+  /**
+   * TODO:
+   *  - 페이지네이션을 잘 작동함. 날먹 개꿀
+   *  - 문제는 검색 옵션. -> 이름으로 검색, 내용으로 검색, 작성자로 검색, 작성일로 검색 등등 기능 추가 필요
+   *  - 그리고 테스트 코드 수정해야함
+   */
   @Get()
-  getAllPost(): Promise<PostEntity[]> {
-    return this.postsService.getAllPost();
+  getAllPost(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number = 1,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number = 10,
+  ) {
+    limit = limit > 100 ? 100 : limit;
+
+    return this.postsService.paginate({
+      page,
+      limit,
+      route: `${this.configService.get('DOMAIN')}/posts`,
+    });
   }
 
   @Get(':id')

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -25,7 +25,7 @@ export class PostsService {
     private postsRepository: Repository<PostEntity>,
   ) {}
 
-  async paginate(
+  async getPostListPaginateWithFilter(
     paginationOptions: IPaginationOptions,
     filterOptions: FilterOptions,
   ): Promise<Pagination<PostEntity>> {

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -4,6 +4,11 @@ import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
+import {
+  paginate,
+  IPaginationOptions,
+  Pagination,
+} from 'nestjs-typeorm-paginate';
 
 @Injectable()
 export class PostsService {
@@ -14,6 +19,10 @@ export class PostsService {
 
   async getAllPost(): Promise<PostEntity[]> {
     return await this.postsRepository.find();
+  }
+
+  async paginate(options: IPaginationOptions): Promise<Pagination<PostEntity>> {
+    return paginate<PostEntity>(this.postsRepository, options);
   }
 
   async getOnePost(id: number): Promise<PostEntity> {

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -29,7 +29,9 @@ export class PostsService {
     paginationOptions: IPaginationOptions,
     filterOptions: FilterOptions,
   ): Promise<Pagination<PostEntity>> {
-    const queryBuilder = this.postsRepository.createQueryBuilder('post');
+    const queryBuilder = this.postsRepository
+      .createQueryBuilder('post')
+      .leftJoinAndSelect('post.img', 'img');
 
     if (filterOptions.title) {
       queryBuilder.andWhere('post.title like :title', {


### PR DESCRIPTION
## 추가 된 기능
- `nestjs-typeorm-paginate` 패키지 추가
- 위 패키지로 페이지네이션 구현
- `postsSerivce`에서 단순하게 모든 게시글 데이터 리턴하던 `getAllPost()` 함수를 `getPostListPaginateWithFilter()`로 개선
  - `queryBuilder`로 필터 기능 구현
- `postsController`에서 다양한 쿼리값을 받아 클라이언트에서 원하는 데이터를 받도록 수정
  - 페이지네이션 쿼리
    - page: number // 페이지 넘버 (기본: 1)
    - limit: number // 각 페이지 데이터량 (기본: 10; max: 100)
  - 필터용 쿼리 
    - title: string
    - sort: 'DESC' | 'ASC' 
    - tags: string[]
    - artTypes: artType[]
- unit 테스트 수정
- e2e 테스트 수정